### PR TITLE
Use fabric-api mod ID for Fabric API in fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,7 +35,7 @@
 	"depends": {
 		"minecraft": ">=1.19",
 		"fabricloader": ">=0.14.11",
-		"fabric": "*",
+		"fabric-api": "*",
 		"java": ">=17"
 	}
 }


### PR DESCRIPTION
As of Minecraft 1.19.2, Fabric API's mod ID has changed from fabric to fabric-api. Fabric API still supports the 'fabric' mod ID for backwards compatibility, but users may be confused when they see that a mod depends on 'fabric'.