### PR TITLE
Improve toggle notifiers

### DIFF
--- a/src/main/java/net/clayborn/accurateblockplacement/AccurateBlockPlacementMod.java
+++ b/src/main/java/net/clayborn/accurateblockplacement/AccurateBlockPlacementMod.java
@@ -36,12 +36,12 @@ public class AccurateBlockPlacementMod implements ClientModInitializer
 			while(place_keybind.wasPressed()) {
 				isAccurateBlockPlacementEnabled = !isAccurateBlockPlacementEnabled;
 				AccurateBlockPlacementConfig.save();
-				MC.inGameHud.getChatHud().addMessage(isAccurateBlockPlacementEnabled ? Text.translatable("net.clayborn.accurateblockplacement.modplacementmodemessage") : Text.translatable("net.clayborn.accurateblockplacement.vanillaplacementmodemessage"));
+				MC.player.sendMessage(isAccurateBlockPlacementEnabled ? Text.translatable("net.clayborn.accurateblockplacement.modplacementmodemessage") : Text.translatable("net.clayborn.accurateblockplacement.vanillaplacementmodemessage"), true);
 			}
 			while(break_keybind.wasPressed()) {
 				isFastBlockBreakingEnabled = !isFastBlockBreakingEnabled;
 				AccurateBlockPlacementConfig.save();
-				MC.inGameHud.getChatHud().addMessage(isFastBlockBreakingEnabled ? Text.translatable("net.clayborn.accurateblockplacement.fastbreakingenabled") : Text.translatable("net.clayborn.accurateblockplacement.fastbreakingdisabled"));
+				MC.player.sendMessage(isFastBlockBreakingEnabled ? Text.translatable("net.clayborn.accurateblockplacement.fastbreakingenabled") : Text.translatable("net.clayborn.accurateblockplacement.fastbreakingdisabled"), true);
 			}
 		});
 	}

--- a/src/main/resources/assets/accurateblockplacement/lang/en_us.json
+++ b/src/main/resources/assets/accurateblockplacement/lang/en_us.json
@@ -1,10 +1,10 @@
 {
   "net.clayborn.accurateblockplacement.togglevanillaplacement": "Toggle Placement Mode",
-  "net.clayborn.accurateblockplacement.modplacementmodemessage": "Accurate block placement mode is now enabled!",
-  "net.clayborn.accurateblockplacement.vanillaplacementmodemessage": "Vanilla block placement mode is now enabled!",
+  "net.clayborn.accurateblockplacement.modplacementmodemessage": "Accurate block placement: §2true",
+  "net.clayborn.accurateblockplacement.vanillaplacementmodemessage": "Accurate block placement: §4false",
   "net.clayborn.accurateblockplacement.togglefastbreaking": "Toggle Breaking Mode",
-  "net.clayborn.accurateblockplacement.fastbreakingenabled": "Fast block breaking mode is now enabled!",
-  "net.clayborn.accurateblockplacement.fastbreakingdisabled": "Vanilla block breaking mode is now enabled!",
+  "net.clayborn.accurateblockplacement.fastbreakingenabled": "Fast block breaking: §2true",
+  "net.clayborn.accurateblockplacement.fastbreakingdisabled": "Fast block breaking: §4false",
   "text.autoconfig.accurateblockplacement.title": "Accurate Block Placement",
   "text.autoconfig.accurateblockplacement.option.accuratePlacementEnabled": "Accurate block placement enabled",
   "text.autoconfig.accurateblockplacement.option.fastBreakingEnabled": "Fast block breaking enabled"


### PR DESCRIPTION
The chat messages that notify you that you have toggled one of the features are hard to tell from only a glance what they mean. I figured that they should just have the name of the thing it's toggling and just say on or off. Easy to read and understand without having to actively read the message every time you wanna check if it's on or off. 
Also, having the notifiers as full chat messages is kinda annoying. Especially now when the 'Fast block breaking' feature which, personally, I toggle a lot when working on projects, and all it does is spam the chat. So I made it more convenient.

You don't have to merge this if you don't want to, but I just thought some feedback from an active user might be useful.